### PR TITLE
upgrade intent rescope for sending

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,17 +329,6 @@ dependencies = [
  "futures",
  "pharos",
  "rustc_version",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -663,11 +701,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "6c6b2562119bf28c3439f7f02db99faf0aa1a8cdfe5772a2ee155d32227239f0"
 dependencies = [
  "jobserver",
+ "libc",
 ]
 
 [[package]]
@@ -724,42 +763,44 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
 dependencies = [
- "atty",
- "bitflags 1.3.2",
+ "clap_builder",
  "clap_derive",
- "clap_lex",
- "indexmap 1.9.3",
  "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
  "strsim",
- "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.25"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "coins-bip32"
@@ -816,6 +857,12 @@ dependencies = [
  "sha3",
  "thiserror",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "combine"
@@ -1141,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8810e7e2cf385b1e9b50d68264908ec367ba642c96d02edfe61c39e88e2a3c01"
+checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
 
 [[package]]
 name = "derive-getters"
@@ -2061,8 +2108,7 @@ dependencies = [
 [[package]]
 name = "graphcast-sdk"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84f56df57a05e3e01f08c3cce8ef8ce2feefc81ebfc50af9353b9060fb5f7c1"
+source = "git+https://github.com/graphops/graphcast-sdk?branch=hope/config-refactor#6ab6583fd672eb29bd36edb6468be30c30aa70f9"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -2251,15 +2297,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -2518,7 +2555,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "rustix",
  "windows-sys",
 ]
@@ -2659,9 +2696,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
@@ -2937,7 +2974,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
 ]
 
@@ -3000,7 +3037,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -3077,12 +3113,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "overload"
@@ -3198,9 +3228,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d2d1d55045829d65aad9d389139882ad623b33b904e7c9f1b10c5b8927298e5"
+checksum = "1acb4a4365a13f749a93f1a094a7805e5cfa0955373a9de860d962eaa3a5fe5a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -3435,7 +3465,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "time 0.3.24",
+ "time 0.3.25",
  "url",
 ]
 
@@ -3769,9 +3799,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "1ee020b1716f0a80e2ace9b03441a749e402e86712f15f16fe8a8f75afac732f"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -3782,9 +3812,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.5"
+version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
+checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
  "ring",
@@ -4065,18 +4095,18 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.179"
+version = "1.0.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5bf42b8d227d4abf38a1ddb08602e229108a517cd4e5bb28f9c7eaafdce5c0"
+checksum = "0ea67f183f058fe88a4e3ec6e2788e003840893b91bac4559cabedd00863b3ed"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.179"
+version = "1.0.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "741e124f5485c7e60c03b043f79f320bff3527f4bbf12cf3831750dc46a0ec2c"
+checksum = "24e744d7782b686ab3b73267ef05697159cc0e5abbed3f47f9933165e5219036"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4660,21 +4690,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-
-[[package]]
 name = "thiserror"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4717,9 +4732,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79eabcd964882a646b3584543ccabeae7869e9ac32a46f6f22b7a5bd405308b"
+checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
 dependencies = [
  "deranged",
  "serde",
@@ -5216,6 +5231,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5556,9 +5577,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd122eb777186e60c3fdf765a58ac76e41c582f1f535fbf3314434c6b58f3f7"
+checksum = "f46aab759304e4d7b2075a9aecba26228bb073ee8c50db796b2c72c676b5d807"
 dependencies = [
  "memchr",
 ]
@@ -5628,7 +5649,7 @@ dependencies = [
  "hmac",
  "pbkdf2 0.11.0",
  "sha1",
- "time 0.3.24",
+ "time 0.3.25",
  "zstd",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2107,8 +2107,8 @@ dependencies = [
 
 [[package]]
 name = "graphcast-sdk"
-version = "0.4.0"
-source = "git+https://github.com/graphops/graphcast-sdk?branch=hope/config-refactor#6ab6583fd672eb29bd36edb6468be30c30aa70f9"
+version = "0.4.1"
+source = "git+https://github.com/graphops/graphcast-sdk?branch=hope/auto-resolve-latest-hash#3b1c07450bc6a4a99f8b5ff4bf4f4c4ec83f457e"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ keywords = ["graphprotocol", "data-integrity", "Indexer", "waku", "p2p"]
 categories = ["network-programming", "web-programming::http-client"]
 
 [dependencies]
-# graphcast-sdk = "0.4.0"
-graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk", branch = "hope/config-refactor" }
+graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk", branch = "hope/auto-resolve-latest-hash" }
 once_cell = "1.17"
 chrono = "0.4"
 serde = { version = "1.0.163", features = ["rc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ keywords = ["graphprotocol", "data-integrity", "Indexer", "waku", "p2p"]
 categories = ["network-programming", "web-programming::http-client"]
 
 [dependencies]
-graphcast-sdk = "0.4.0"
+# graphcast-sdk = "0.4.0"
+graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk", branch = "hope/config-refactor" }
 once_cell = "1.17"
 chrono = "0.4"
 serde = { version = "1.0.163", features = ["rc"] }
@@ -22,14 +23,7 @@ thiserror = "1.0.40"
 ethers = "2.0.4"
 dotenv = "0.15"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = [
-    "env-filter",
-    "ansi",
-    "fmt",
-    "std",
-    "json",
-] }
-clap = { version = "3.2.25", features = ["derive", "env"] }
+clap = { version = "4.3.1", features = ["derive", "env"] }
 prost = "0.11"
 ethers-contract = "2.0.4"
 ethers-core = "2.0.4"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To send a message on Graphcast mainnet for the subgraph deployment "QmacQnSgia4i
 cargo run -- --private-key "abcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefg1" \
 --graph-account "0xe9a1cabd57700b17945fd81feefba82340d9568f" \
 --identifier "QmacQnSgia4iDPWHpeY6aWxesRFdb8o5DKZUx96zZqEWrB" \
---new-hash "QmTHIS_NEW_HASH" \
+--new-hash "QmVVfLWowm1xkqc41vcygKNwFUvpsDSMbHdHghxmDVmH9x" \
 --subgraph-id "CnJMdCkW3pr619gsJVtUPAWxspALPdCMw6o7obzYBNp3" \
 --index-network "goerli" \
 --migration-time 1689205934

--- a/README.md
+++ b/README.md
@@ -5,28 +5,25 @@
 
 ## Introduction
 
-This is a Graphcast Radio focused on sending a single message about particular subgraphs on Graphcast P2P network. The available message type is a version upgrade annoucement message from a subgraph owner.
+This is a Graphcast Radio focused on sending a single message about particular subgraphs on Graphcast P2P network. The available message type is `UpgradeIntentMessage` from a subgraph owner.
 
-### Version Upgrade message
+### Upgrade Pre-sync
 
-When developers publish a new version (subgraph deployment) to their subgraph, data service instability may occur while their API queries the pre-existing version. Indexers may require some time to sync a subgraph to the chainhead after they have stopped syncing the previous deployment. To decrease the upgrade friction, developers can send a message before publishing the subgraph, including the old deployment hash, new deployment hash, matching subgraph id, the time they would like to publish the version. 
+When developers publish a new version (subgraph deployment) to their subgraph, data service instability may occur while their API queries the pre-existing version. Indexers may require some time to sync a subgraph to the chainhead after they have stopped syncing the previous deployment. To decrease the upgrade friction, developers can send a message before publishing the subgraph on current deployment hash's Graphcast channel, which includes the subgraph id, corresponding new deployment hash, and the represented graph account that must be validated to be the subgraph's owner. 
 
-Subgraph radios subscribed to the same topic and process this information immediately, potentially start offchain syncing the new deployment in their graph node. 
+Indexers running the subgraph radio and listening to that channel will in turn receive the message and potentially start to offchain new deployment.
 
 It is still at the subgraph developers' discretion to await for the indexers to sync upto chainhead, in which point they can publish the staged version without disrupting API usage.
 
 ## 🆙 Example usage
 
-To send a message on Graphcast mainnet for the subgraph deployment "QmacQnSgia4iDPWHpeY6aWxesRFdb8o5DKZUx96zZqEWrB", we can 
+To send a message on Graphcast mainnet for the subgraph deployment "QmacQnSgia4iDPWHpeY6aWxesRFdb8o5DKZUx96zZqEWrB", we would need its subgraph id "CnJMdCkW3pr619gsJVtUPAWxspALPdCMw6o7obzYBNp3", private key to the graph account or an operator of the graph account, the subgraph owner's graph account, and the new deployment hash. You can supply them as an CLI argument
 
 ```
 cargo run -- --private-key "abcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefgabcdefg1" \
 --graph-account "0xe9a1cabd57700b17945fd81feefba82340d9568f" \
---identifier "QmacQnSgia4iDPWHpeY6aWxesRFdb8o5DKZUx96zZqEWrB" \
 --new-hash "QmVVfLWowm1xkqc41vcygKNwFUvpsDSMbHdHghxmDVmH9x" \
---subgraph-id "CnJMdCkW3pr619gsJVtUPAWxspALPdCMw6o7obzYBNp3" \
---index-network "goerli" \
---migration-time 1689205934
+--subgraph-id "CnJMdCkW3pr619gsJVtUPAWxspALPdCMw6o7obzYBNp3"
 ```
 
 The entire process from running the binary to sending the message should take ~45 seconds. One can expect the terminal to output the following:

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,11 +6,10 @@ use tracing::info;
 
 use graphcast_sdk::{
     build_wallet,
-    callbook::CallBook,
     graphcast_agent::{
         message_typing::IdentityValidation, GraphcastAgentConfig, GraphcastAgentError,
     },
-    graphql::{client_network::query_network_subgraph, QueryError},
+    graphql::QueryError,
     init_tracing, wallet_address, GraphcastNetworkName, LogFormat,
 };
 
@@ -110,27 +109,6 @@ impl Config {
         )
         .await
     }
-
-    pub async fn basic_info(&self) -> Result<(&str, f32), QueryError> {
-        let my_address = self.graph_stack().graph_account();
-        let my_stake = query_network_subgraph(self.graph_stack().network_subgraph(), my_address)
-            .await
-            .unwrap()
-            .indexer_stake();
-        info!(
-            my_address,
-            my_stake, "Initializing radio operator for indexer identity",
-        );
-        Ok((my_address, my_stake))
-    }
-
-    pub fn callbook(&self) -> CallBook {
-        CallBook::new(
-            self.graph_stack().registry_subgraph.clone(),
-            self.graph_stack().network_subgraph.clone(),
-            None,
-        )
-    }
 }
 
 #[derive(Clone, Debug, Args, Serialize, Deserialize, Getters, Default)]
@@ -140,7 +118,7 @@ pub struct GraphStack {
         long,
         value_name = "GRAPH_ACCOUNT",
         env = "GRAPH_ACCOUNT",
-        help = "Graph account corresponding to Graphcast operator"
+        help = "Graph account corresponding to the operator (must be the subgraph owner of the upgrade intent subgraph)"
     )]
     pub graph_account: String,
     #[clap(
@@ -354,20 +332,6 @@ pub struct Waku {
 pub struct MessageOpt {
     #[clap(
         long,
-        value_name = "IDENTIFIER",
-        env = "IDENTIFIER",
-        help = "Subgraph hash is used to be the message content identifier"
-    )]
-    pub identifier: String,
-    #[clap(
-        long,
-        value_name = "NEW_HASH",
-        env = "NEW_HASH",
-        help = "Subgraph hash for the upgrade version of the subgraph"
-    )]
-    pub new_hash: String,
-    #[clap(
-        long,
         value_name = "SUBGRAPH_ID",
         env = "SUBGRAPH_ID",
         help = "Subgraph id shared by the old and new deployment"
@@ -375,18 +339,11 @@ pub struct MessageOpt {
     pub subgraph_id: String,
     #[clap(
         long,
-        value_name = "INDEX_NETWORK",
-        env = "INDEX_NETWORK",
-        help = "Subgraph id shared by the old and new deployment"
+        value_name = "NEW_HASH",
+        env = "NEW_HASH",
+        help = "Subgraph hash for the upgrade version of the subgraph"
     )]
-    pub index_network: String,
-    #[clap(
-        long,
-        value_name = "MIGRATION_TIME",
-        env = "MIGRATION_TIME",
-        help = "UNIX timestamp that the developer plan on migrating the usage"
-    )]
-    pub migration_time: i64,
+    pub new_hash: String,
     #[clap(long, value_name = "MAX_RETRY", env = "MAX_RETRY", default_value = "5")]
     pub max_retry: u64,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Args, Parser};
 use derive_getters::Getters;
 use ethers::signers::WalletError;
 use serde::{Deserialize, Serialize};
@@ -10,10 +10,8 @@ use graphcast_sdk::{
     graphcast_agent::{
         message_typing::IdentityValidation, GraphcastAgentConfig, GraphcastAgentError,
     },
-    graphql::{
-        client_network::query_network_subgraph, client_registry::query_registry, QueryError,
-    },
-    init_tracing, wallet_address,
+    graphql::{client_network::query_network_subgraph, QueryError},
+    init_tracing, wallet_address, GraphcastNetworkName, LogFormat,
 };
 
 #[derive(Clone, Debug, Parser, Serialize, Deserialize, Getters, Default)]
@@ -23,26 +21,121 @@ use graphcast_sdk::{
     author = "GraphOps"
 )]
 pub struct Config {
-    #[clap(
-        long,
-        value_name = "KEY",
-        value_parser = Config::parse_key,
-        env = "PRIVATE_KEY",
-        hide_env_values = true,
-        help = "Private key to the Graphcast ID wallet (Precendence over mnemonics)",
+    #[command(flatten)]
+    pub graph_stack: GraphStack,
+    #[command(flatten)]
+    pub waku: Waku,
+    #[command(flatten)]
+    pub radio_infrastructure: RadioInfrastructure,
+    #[command(flatten)]
+    pub message: MessageOpt,
+    #[arg(
+        short,
+        value_name = "config_file",
+        env = "CONFIG_FILE",
+        help = "Configuration file (toml or yaml format)"
     )]
-    // should keep this value private, this is current public due to the constructing a Config in test-utils
-    // We can get around this by making an explicit function to make config instead of direct build in {}
-    pub private_key: Option<String>,
-    #[clap(
-        long,
-        value_name = "KEY",
-        value_parser = Config::parse_key,
-        env = "MNEMONIC",
-        hide_env_values = true,
-        help = "Mnemonic to the Graphcast ID wallet (first address of the wallet is used; Only one of private key or mnemonic is needed)",
-    )]
-    pub mnemonic: Option<String>,
+    pub config_file: Option<String>,
+}
+
+impl Config {
+    /// Parse config arguments
+    pub fn args() -> Self {
+        // TODO: load config file before parse (maybe add new level of subcommands)
+        let config = Config::parse();
+        std::env::set_var("RUST_LOG", config.radio_infrastructure().log_level.clone());
+        // Enables tracing under RUST_LOG variable
+        init_tracing(config.radio_infrastructure().log_format.to_string()).expect("Could not set up global default subscriber for logger, check environmental variable `RUST_LOG` or the CLI input `log-level`");
+        config
+    }
+
+    /// Validate that private key as an Eth wallet
+    fn parse_key(value: &str) -> Result<String, WalletError> {
+        // The wallet can be stored instead of the original private key
+        let wallet = build_wallet(value)?;
+        let address = wallet_address(&wallet);
+        info!(address, "Resolved Graphcast id");
+        Ok(String::from(value))
+    }
+
+    /// Private key takes precedence over mnemonic
+    pub fn wallet_input(&self) -> Result<&String, ConfigError> {
+        match (
+            &self.graph_stack().private_key,
+            &self.graph_stack().mnemonic,
+        ) {
+            (Some(p), _) => Ok(p),
+            (_, Some(m)) => Ok(m),
+            _ => Err(ConfigError::ValidateInput(
+                "Must provide either private key or mnemonic".to_string(),
+            )),
+        }
+    }
+
+    pub async fn to_graphcast_agent_config(
+        &self,
+    ) -> Result<GraphcastAgentConfig, GraphcastAgentError> {
+        let wallet_key = self.wallet_input().unwrap().to_string();
+        let topics = self.radio_infrastructure().topics.clone();
+
+        info!(
+            radio_name = tracing::field::debug(&self.radio_infrastructure().radio_name.clone()),
+            registry_subgraph =
+                tracing::field::debug(&self.graph_stack().registry_subgraph.clone()),
+            network_subgraph = tracing::field::debug(&self.graph_stack().network_subgraph.clone()),
+            graphcast_network =
+                tracing::field::debug(self.radio_infrastructure().graphcast_network.to_string()),
+            max_retry = self.message().max_retry,
+            "Creating Graphcast Agent",
+        );
+
+        GraphcastAgentConfig::new(
+            wallet_key,
+            self.graph_stack().graph_account.clone(),
+            self.radio_infrastructure().radio_name.clone(),
+            self.graph_stack().registry_subgraph.clone(),
+            self.graph_stack().network_subgraph.clone(),
+            self.radio_infrastructure().id_validation.clone(),
+            None,
+            Some(self.waku().boot_node_addresses.clone()),
+            Some(self.radio_infrastructure().graphcast_network.to_string()),
+            Some(topics),
+            self.waku().waku_node_key.clone(),
+            self.waku().waku_host.clone(),
+            self.waku().waku_port.clone(),
+            self.waku().waku_addr.clone(),
+            self.waku().filter_protocol,
+            self.waku().discv5_enrs.clone(),
+            self.waku().discv5_port,
+        )
+        .await
+    }
+
+    pub async fn basic_info(&self) -> Result<(&str, f32), QueryError> {
+        let my_address = self.graph_stack().graph_account();
+        let my_stake = query_network_subgraph(self.graph_stack().network_subgraph(), my_address)
+            .await
+            .unwrap()
+            .indexer_stake();
+        info!(
+            my_address,
+            my_stake, "Initializing radio operator for indexer identity",
+        );
+        Ok((my_address, my_stake))
+    }
+
+    pub fn callbook(&self) -> CallBook {
+        CallBook::new(
+            self.graph_stack().registry_subgraph.clone(),
+            self.graph_stack().network_subgraph.clone(),
+            None,
+        )
+    }
+}
+
+#[derive(Clone, Debug, Args, Serialize, Deserialize, Getters, Default)]
+#[group(required = true, multiple = true)]
+pub struct GraphStack {
     #[clap(
         long,
         value_name = "GRAPH_ACCOUNT",
@@ -68,56 +161,132 @@ pub struct Config {
     pub network_subgraph: String,
     #[clap(
         long,
-        default_value = "testnet",
-        value_name = "NAME",
-        env = "GRAPHCAST_NETWORK",
-        help = "Supported Graphcast networks: mainnet, testnet",
-        possible_values = ["testnet", "mainnet"],
+        value_name = "KEY",
+        value_parser = Config::parse_key,
+        env = "PRIVATE_KEY",
+        hide_env_values = true,
+        help = "Private key to the Graphcast ID wallet (Precendence over mnemonics)",
     )]
-    pub graphcast_network: String,
+    // should keep this value private, this is current public due to the constructing a Config in test-utils
+    // We can get around this by making an explicit function to make config instead of direct build in {}
+    pub private_key: Option<String>,
+    #[clap(
+        long,
+        value_name = "KEY",
+        value_parser = Config::parse_key,
+        env = "MNEMONIC",
+        hide_env_values = true,
+        help = "Mnemonic to the Graphcast ID wallet (first address of the wallet is used; Only one of private key or mnemonic is needed)",
+    )]
+    pub mnemonic: Option<String>,
+}
+
+#[derive(Clone, Debug, Args, Serialize, Deserialize, Default)]
+#[group(required = false, multiple = true)]
+pub struct RadioInfrastructure {
+    #[clap(
+        long,
+        value_name = "GRAPHCAST_NETWORK",
+        default_value = "testnet",
+        env = "GRAPHCAST_NETWORK",
+        help = "Supported Graphcast networks: mainnet, testnet"
+    )]
+    pub graphcast_network: GraphcastNetworkName,
     #[clap(
         long,
         value_name = "[TOPIC]",
         value_delimiter = ',',
         env = "TOPICS",
-        help = "Comma separated static list of content topics to subscribe to (Static list to include) (right now just send message to the first element of the vec?"
+        help = "Comma separated static list of content topics to subscribe to (Static list to include)"
     )]
     pub topics: Vec<String>,
     #[clap(
         long,
-        value_name = "IDENTIFIER",
-        env = "IDENTIFIER",
-        help = "Subgraph hash is used to be the message content identifier"
+        value_name = "SLACK_TOKEN",
+        help = "Slack bot API token",
+        env = "SLACK_TOKEN"
     )]
-    pub identifier: String,
+    pub slack_token: Option<String>,
     #[clap(
         long,
-        value_name = "NEW_HASH",
-        env = "NEW_HASH",
-        help = "Subgraph hash for the upgrade version of the subgraph"
+        value_name = "SLACK_CHANNEL",
+        help = "Name of Slack channel to send messages to (has to be a public channel)",
+        env = "SLACK_CHANNEL"
     )]
-    pub new_hash: String,
+    pub slack_channel: Option<String>,
     #[clap(
         long,
-        value_name = "SUBGRAPH_ID",
-        env = "SUBGRAPH_ID",
-        help = "Subgraph id shared by the old and new deployment"
+        value_name = "DISCORD_WEBHOOK",
+        help = "Discord webhook URL to send messages to",
+        env = "DISCORD_WEBHOOK"
     )]
-    pub subgraph_id: String,
+    pub discord_webhook: Option<String>,
     #[clap(
         long,
-        value_name = "INDEX_NETWORK",
-        env = "INDEX_NETWORK",
-        help = "Subgraph id shared by the old and new deployment"
+        value_name = "TELEGRAM_TOKEN",
+        help = "Telegram Bot API Token",
+        env = "TELEGRAM_TOKEN"
     )]
-    pub index_network: String,
+    pub telegram_token: Option<String>,
     #[clap(
         long,
-        value_name = "MIGRATION_TIME",
-        env = "MIGRATION_TIME",
-        help = "UNIX timestamp that the developer plan on migrating the usage"
+        value_name = "TELEGRAM_CHAT_ID",
+        help = "Id of Telegram chat (DM or group) to send messages to",
+        env = "TELEGRAM_CHAT_ID"
     )]
-    pub migration_time: i64,
+    pub telegram_chat_id: Option<i64>,
+    #[clap(
+        long,
+        value_name = "RADIO_NAME",
+        env = "RADIO_NAME",
+        default_value = "subgraph-radio"
+    )]
+    pub radio_name: String,
+    #[clap(
+        long,
+        value_name = "ID_VALIDATION",
+        value_enum,
+        default_value = "indexer",
+        env = "ID_VALIDATION",
+        help = "Identity validaiton mechanism for message signers",
+        long_help = "Identity validaiton mechanism for message signers. Default: indexer\n
+        no-check: all messages signer is valid, \n
+        valid-address: signer needs to be an valid Eth address, \n
+        graphcast-registered: must be registered at Graphcast Registry, \n
+        graph-network-account: must be a Graph account, \n
+        registered-indexer: must be registered at Graphcast Registry, correspond to and Indexer statisfying indexer minimum stake requirement, \n
+        indexer: must be registered at Graphcast Registry or is a Graph Account, correspond to and Indexer statisfying indexer minimum stake requirement"
+    )]
+    pub id_validation: IdentityValidation,
+    #[clap(
+        long,
+        value_name = "TOPIC_UPDATE_INTERVAL",
+        env = "TOPIC_UPDATE_INTERVAL",
+        default_value = "600"
+    )]
+    pub topic_update_interval: u64,
+    #[clap(
+        long,
+        value_name = "LOG_LEVEL",
+        default_value = "info",
+        help = "logging configurationt to set as RUST_LOG",
+        env = "RUST_LOG"
+    )]
+    pub log_level: String,
+    #[clap(
+        long,
+        value_name = "LOG_FORMAT",
+        env = "LOG_FORMAT",
+        help = "Support logging formats: pretty, json, full, compact",
+        long_help = "pretty: verbose and human readable; json: not verbose and parsable; compact:  not verbose and not parsable; full: verbose and not parsible",
+        default_value = "pretty"
+    )]
+    pub log_format: LogFormat,
+}
+
+#[derive(Clone, Debug, Args, Serialize, Deserialize, Default)]
+#[group(required = false, multiple = true)]
+pub struct Waku {
     #[clap(
         long,
         value_name = "WAKU_HOST",
@@ -176,228 +345,50 @@ pub struct Config {
         env = "DISCV5_PORT"
     )]
     pub discv5_port: Option<u16>,
-    #[clap(
-        long,
-        value_name = "LOG_LEVEL",
-        default_value = "warn,hyper=off,graphcast_sdk=off,one_shot_cli=info",
-        help = "logging configurationt to set as RUST_LOG",
-        env = "RUST_LOG"
-    )]
-    pub log_level: String,
-    #[clap(
-        long,
-        value_name = "SLACK_TOKEN",
-        help = "Slack bot API token",
-        env = "SLACK_TOKEN"
-    )]
-    pub slack_token: Option<String>,
-    #[clap(
-        long,
-        value_name = "SLACK_CHANNEL",
-        help = "Name of Slack channel to send messages to (has to be a public channel)",
-        env = "SLACK_CHANNEL"
-    )]
-    pub slack_channel: Option<String>,
-    #[clap(
-        long,
-        value_name = "DISCORD_WEBHOOK",
-        help = "Discord webhook URL to send messages to",
-        env = "DISCORD_WEBHOOK"
-    )]
-    pub discord_webhook: Option<String>,
-    #[clap(
-        long,
-        value_name = "TELEGRAM_TOKEN",
-        help = "Telegram Bot API Token",
-        env = "TELEGRAM_TOKEN"
-    )]
-    pub telegram_token: Option<String>,
-    #[clap(
-        long,
-        value_name = "TELEGRAM_CHAT_ID",
-        help = "Id of Telegram chat (DM or group) to send messages to",
-        env = "TELEGRAM_CHAT_ID"
-    )]
-    pub telegram_chat_id: Option<i64>,
-    #[clap(
-        long,
-        value_name = "METRICS_HOST",
-        default_value = "0.0.0.0",
-        help = "If port is set, the Radio will expose Prometheus metrics on the given host. This requires having a local Prometheus server running and scraping metrics on the given port.",
-        env = "METRICS_HOST"
-    )]
-    pub metrics_host: String,
-    #[clap(
-        long,
-        value_name = "METRICS_PORT",
-        help = "If set, the Radio will expose Prometheus metrics on the given port (off by default). This requires having a local Prometheus server running and scraping metrics on the given port.",
-        env = "METRICS_PORT"
-    )]
-    pub metrics_port: Option<u16>,
-    #[clap(
-        long,
-        value_name = "SERVER_HOST",
-        default_value = "0.0.0.0",
-        help = "If port is set, the Radio will expose API service on the given host.",
-        env = "SERVER_HOST"
-    )]
-    pub server_host: String,
-    #[clap(
-        long,
-        value_name = "SERVER_PORT",
-        help = "If set, the Radio will expose API service on the given port (off by default).",
-        env = "SERVER_PORT"
-    )]
-    pub server_port: Option<u16>,
-    #[clap(
-        long,
-        value_name = "PERSISTENCE_FILE_PATH",
-        help = "If set, the Radio will periodically store states of the program to the file in json format",
-        env = "PERSISTENCE_FILE_PATH"
-    )]
-    pub persistence_file_path: Option<String>,
-    #[clap(
-        long,
-        value_name = "LOG_FORMAT",
-        env = "LOG_FORMAT",
-        help = "Support logging formats: pretty, json, full, compact",
-        long_help = "pretty: verbose and human readable; json: not verbose and parsable; compact:  not verbose and not parsable; full: verbose and not parsible",
-        possible_values = ["pretty", "json", "full", "compact"],
-        default_value = "pretty"
-    )]
-    pub log_format: String,
-    #[clap(
-        long,
-        value_name = "RADIO_NAME",
-        env = "RADIO_NAME",
-        default_value = "subgraph-radio"
-    )]
-    pub radio_name: String,
     #[clap(long, value_name = "FILTER_PROTOCOL", env = "ENABLE_FILTER_PROTOCOL")]
     pub filter_protocol: Option<bool>,
-    #[clap(
-        long,
-        value_name = "ID_VALIDATION",
-        value_enum,
-        env = "ID_VALIDATION",
-        default_value = "subgraph-staker",
-        help = "Identity validaiton mechanism for message signers",
-        long_help = "Identity validaiton mechanism for message signers\n
-        no-check: all messages signer is valid, \n
-        valid-address: signer needs to be an valid Eth address, \n
-        graphcast-registered: must be registered at Graphcast Registry, \n
-        graph-network-account: must be a Graph account, \n
-        registered-indexer: must be registered at Graphcast Registry, correspond to and Indexer statisfying indexer minimum stake requirement, \n
-        indexer: must be registered at Graphcast Registry or is a Graph Account, correspond to and Indexer statisfying indexer minimum stake requirement"
-    )]
-    pub id_validation: IdentityValidation,
-    #[clap(
-        long,
-        value_name = "TOPIC_UPDATE_INTERVAL",
-        env = "TOPIC_UPDATE_INTERVAL",
-        default_value = "600"
-    )]
-    pub topic_update_interval: u64,
-    #[clap(long, value_name = "MAX_RETRY", env = "MAX_RETRY", default_value = "5")]
-    pub max_retry: u64,
 }
 
-impl Config {
-    /// Parse config arguments
-    pub fn args() -> Self {
-        // TODO: load config file before parse (maybe add new level of subcommands)
-        let config = Config::parse();
-        std::env::set_var("RUST_LOG", config.log_level.clone());
-        // Enables tracing under RUST_LOG variable
-        init_tracing(config.log_format.clone()).expect("Could not set up global default subscriber for logger, check environmental variable `RUST_LOG` or the CLI input `log-level`");
-        config
-    }
-
-    /// Validate that private key as an Eth wallet
-    fn parse_key(value: &str) -> Result<String, WalletError> {
-        // The wallet can be stored instead of the original private key
-        let wallet = build_wallet(value)?;
-        let address = wallet_address(&wallet);
-        info!(address, "Resolved Graphcast id");
-        Ok(String::from(value))
-    }
-
-    /// Private key takes precedence over mnemonic
-    pub fn wallet_input(&self) -> Result<&String, ConfigError> {
-        match (&self.private_key, &self.mnemonic) {
-            (Some(p), _) => Ok(p),
-            (_, Some(m)) => Ok(m),
-            _ => Err(ConfigError::ValidateInput(
-                "Must provide either private key or mnemonic".to_string(),
-            )),
-        }
-    }
-
-    pub async fn to_graphcast_agent_config(
-        &self,
-    ) -> Result<GraphcastAgentConfig, GraphcastAgentError> {
-        let wallet_key = self.wallet_input().unwrap().to_string();
-        let topics = self.topics.clone();
-
-        info!(
-            radio_name = tracing::field::debug(&self.radio_name.clone()),
-            registry_subgraph = tracing::field::debug(&self.registry_subgraph.clone()),
-            network_subgraph = tracing::field::debug(&self.network_subgraph.clone()),
-            graphcast_network = tracing::field::debug(self.graphcast_network.to_owned()),
-            max_retry = self.max_retry,
-            "Creating Graphcast Agent",
-        );
-
-        GraphcastAgentConfig::new(
-            wallet_key,
-            self.graph_account.clone(),
-            self.radio_name.clone(),
-            self.registry_subgraph.clone(),
-            self.network_subgraph.clone(),
-            self.id_validation.clone(),
-            None,
-            Some(self.boot_node_addresses.clone()),
-            Some(self.graphcast_network.to_owned()),
-            Some(topics),
-            self.waku_node_key.clone(),
-            self.waku_host.clone(),
-            self.waku_port.clone(),
-            self.waku_addr.clone(),
-            self.filter_protocol,
-            self.discv5_enrs.clone(),
-            self.discv5_port,
-        )
-        .await
-    }
-
-    pub async fn basic_info(&self) -> Result<(String, f32), QueryError> {
-        // Using unwrap directly as the query has been ran in the set-up validation
-        let wallet = build_wallet(
-            self.wallet_input()
-                .map_err(|e| QueryError::Other(e.into()))?,
-        )
-        .map_err(|e| QueryError::Other(e.into()))?;
-        // The query here must be Ok but so it is okay to panic here
-        // Alternatively, make validate_set_up return wallet, address, and stake
-        let my_address = query_registry(self.registry_subgraph(), &wallet_address(&wallet)).await?;
-        let my_stake = query_network_subgraph(self.network_subgraph(), &my_address)
-            .await
-            .unwrap()
-            .indexer_stake();
-        info!(
-            my_address,
-            my_stake, "Initializing radio operator for indexer identity",
-        );
-        Ok((my_address, my_stake))
-    }
-
-    pub fn callbook(&self) -> CallBook {
-        CallBook::new(
-            self.registry_subgraph.clone(),
-            self.network_subgraph.clone(),
-            None,
-        )
-    }
+#[derive(Clone, Debug, Args, Serialize, Deserialize, Default)]
+#[group(required = true, multiple = true)]
+pub struct MessageOpt {
+    #[clap(
+        long,
+        value_name = "IDENTIFIER",
+        env = "IDENTIFIER",
+        help = "Subgraph hash is used to be the message content identifier"
+    )]
+    pub identifier: String,
+    #[clap(
+        long,
+        value_name = "NEW_HASH",
+        env = "NEW_HASH",
+        help = "Subgraph hash for the upgrade version of the subgraph"
+    )]
+    pub new_hash: String,
+    #[clap(
+        long,
+        value_name = "SUBGRAPH_ID",
+        env = "SUBGRAPH_ID",
+        help = "Subgraph id shared by the old and new deployment"
+    )]
+    pub subgraph_id: String,
+    #[clap(
+        long,
+        value_name = "INDEX_NETWORK",
+        env = "INDEX_NETWORK",
+        help = "Subgraph id shared by the old and new deployment"
+    )]
+    pub index_network: String,
+    #[clap(
+        long,
+        value_name = "MIGRATION_TIME",
+        env = "MIGRATION_TIME",
+        help = "UNIX timestamp that the developer plan on migrating the usage"
+    )]
+    pub migration_time: i64,
+    #[clap(long, value_name = "MAX_RETRY", env = "MAX_RETRY", default_value = "5")]
+    pub max_retry: u64,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/messages/upgrade.rs
+++ b/src/messages/upgrade.rs
@@ -2,80 +2,47 @@ use async_graphql::SimpleObject;
 use ethers_contract::EthAbiType;
 use ethers_core::types::transaction::eip712::Eip712;
 use ethers_derive_eip712::*;
-
-use graphcast_sdk::networks::NetworkName;
 use prost::Message;
 use serde::{Deserialize, Serialize};
 
 #[derive(Eip712, EthAbiType, Clone, Message, Serialize, Deserialize, PartialEq, SimpleObject)]
 #[eip712(
-    name = "VersionUpgradeMessage",
+    name = "UpgradeIntentMessage",
     version = "0",
     chain_id = 1,
     verifying_contract = "0xc944e90c64b2c07662a292be6244bdf05cda44a7"
 )]
-pub struct VersionUpgradeMessage {
-    // identify through the current subgraph deployment
+pub struct UpgradeIntentMessage {
+    /// subgraph id shared by both versions of the subgraph deployment
     #[prost(string, tag = "1")]
-    pub identifier: String,
+    pub subgraph_id: String,
     // new version of the subgraph has a new deployment hash
     #[prost(string, tag = "2")]
     pub new_hash: String,
-    /// subgraph id shared by both versions of the subgraph deployment
-    #[prost(string, tag = "6")]
-    pub subgraph_id: String,
     /// nonce cached to check against the next incoming message
     #[prost(int64, tag = "3")]
     pub nonce: i64,
-    /// blockchain relevant to the message
-    #[prost(string, tag = "4")]
-    pub network: String,
-    /// estimated timestamp for the usage to switch to the new version
-    #[prost(int64, tag = "5")]
-    pub migrate_time: i64,
     /// Graph account sender - expect the sender to be subgraph owner
-    #[prost(string, tag = "7")]
+    #[prost(string, tag = "4")]
     pub graph_account: String,
 }
 
-impl VersionUpgradeMessage {
-    pub fn new(
-        identifier: String,
-        new_hash: String,
-        subgraph_id: String,
-        nonce: i64,
-        network: String,
-        migrate_time: i64,
-        graph_account: String,
-    ) -> Self {
-        VersionUpgradeMessage {
-            identifier,
-            new_hash,
+impl UpgradeIntentMessage {
+    pub fn new(subgraph_id: String, new_hash: String, nonce: i64, graph_account: String) -> Self {
+        UpgradeIntentMessage {
             subgraph_id,
+            new_hash,
             nonce,
-            network,
-            migrate_time,
             graph_account,
         }
     }
 
     pub fn build(
-        identifier: String,
+        subgraph_id: String,
         new_hash: String,
         timestamp: i64,
-        subgraph_id: String,
-        network: NetworkName,
-        migrate_time: i64,
         graph_account: String,
     ) -> Self {
-        VersionUpgradeMessage::new(
-            identifier,
-            new_hash,
-            subgraph_id,
-            timestamp,
-            network.to_string(),
-            migrate_time,
-            graph_account,
-        )
+        UpgradeIntentMessage::new(subgraph_id, new_hash, timestamp, graph_account)
     }
 }

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -33,7 +33,7 @@ impl RadioOperator {
                 .expect("Initialize Graphcast agent");
         let graphcast_agent = Arc::new(agent);
         // Provide topics to Graphcast agent
-        let topics = vec![config.identifier.clone()];
+        let topics = vec![config.message().identifier.clone()];
         debug!(
             topics = tracing::field::debug(&topics),
             "Found content topics for subscription",
@@ -56,7 +56,8 @@ impl RadioOperator {
     pub async fn run(&'static self) {
         let mut current_attempt: u64 = 0;
         let mut res = self.gossip_one_shot().await;
-        while current_attempt < self.config.max_retry && res.is_err() {
+        // Try again if the gossip failed to send while the attempt number is within max_retry
+        while res.is_err() && current_attempt < self.config.message().max_retry {
             warn!(
                 err = tracing::field::debug(&res),
                 current_attempt, "Failed to gossip, retry"

--- a/src/operator/operation.rs
+++ b/src/operator/operation.rs
@@ -9,13 +9,13 @@ use crate::operator::RadioOperator;
 impl RadioOperator {
     pub async fn gossip_one_shot(&self) -> Result<String, GraphcastAgentError> {
         // configure radio config to parse in a subcommand for the radio payload message?
-        let identifier = self.config.identifier.clone();
-        let new_hash = self.config.new_hash.clone();
-        let subgraph_id = self.config.subgraph_id.clone();
+        let identifier = self.config.message().identifier.clone();
+        let new_hash = self.config.message().new_hash.clone();
+        let subgraph_id = self.config.message().subgraph_id.clone();
         let time = Utc::now().timestamp();
-        let network = self.config.index_network();
-        let migrate_time = self.config.migration_time;
-        let graph_account = self.config.graph_account.clone();
+        let network = &self.config.message().index_network;
+        let migrate_time = self.config.message().migration_time;
+        let graph_account = self.config.graph_stack().graph_account.clone();
         let radio_message = VersionUpgradeMessage::build(
             identifier.clone(),
             new_hash.clone(),


### PR DESCRIPTION
### Description

- Remove requirement for `identifier`, use `subgraph_id` and `graph_account` to auto-resolve the content_topic for sending the message
- Remove `network` and `migrate_time`

### Issue link (if applicable)

Part of https://github.com/graphops/graphcast-meta/issues/17

### Checklist
- [x] Are tests up-to-date with the new changes? 
- [x] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
