### PR TITLE
presync feedback loop - subcommand indexing status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,6 +2123,7 @@ dependencies = [
  "graphcast-sdk",
  "once_cell",
  "prost",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror",
@@ -3649,9 +3650,9 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "reqwest"
-version = "0.11.18"
+version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
  "base64 0.21.2",
  "bytes",
@@ -3688,7 +3689,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.22.6",
+ "webpki-roots 0.25.2",
  "winreg",
 ]
 
@@ -5409,9 +5410,9 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-streams"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -5442,21 +5443,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
 dependencies = [
  "rustls-webpki 0.100.1",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "which"
@@ -5586,11 +5584,12 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.10.1"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "winapi",
+ "cfg-if",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ ethers-contract = "2.0.4"
 ethers-core = "2.0.4"
 ethers-derive-eip712 = "1.0.2"
 async-graphql = "4.0.16"
+reqwest = "0.11.20"
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ When developers publish a new version (subgraph deployment) to their subgraph, d
 
 Indexers running the subgraph radio and listening to that channel will in turn receive the message and potentially start to offchain new deployment.
 
-It is still at the subgraph developers' discretion to await for the indexers to sync upto chainhead, in which point they can publish the staged version without disrupting API usage.
+It is still at the subgraph developers' discretion to await for the indexers to sync upto chainhead, in which point they can publish the staged version without disrupting API usage. This tool provides a convinence function that allows subgraph developer to ....
 
 ## 🆙 Example usage
+
+### UpgradePresync
 
 To send a message on Graphcast mainnet for the subgraph deployment "QmacQnSgia4iDPWHpeY6aWxesRFdb8o5DKZUx96zZqEWrB", we would need its subgraph id "CnJMdCkW3pr619gsJVtUPAWxspALPdCMw6o7obzYBNp3", private key to the graph account or an operator of the graph account, the subgraph owner's graph account, and the new deployment hash. You can supply them as an CLI argument
 
@@ -40,6 +42,15 @@ The entire process from running the binary to sending the message should take ~4
 2023-07-31T17:56:59.328490Z  INFO Sent message, msg_id: "0xc6b1131e0f8302abe48057f6fc69722ab46bd4285c2c4a8a8bdca6b221dcda96"
 ```
 
+### IndexingStatus
+
+After sending `UpgradeIntentMessage`, a developer can periodically check the indexing status of the new subgraph deployment at the public APIs of the indexers who actively allocates on the current version of the subgraph.
+
+Same arguments here can be used as the argument for `UpgradeIntentMessage`. However, gossips are not involved in this operation and the queries are made through deterministic queries. 
+
+```
+cargo run indexing-status --subgraph-id "0x00000444e5a1a667663b0adfd853e8efa0470698-0" --new-hash QmfDJFYaDX7BdwT6rYa8Bx71vPjTueUVDN99pdwFgysDiZ
+```
 
 ## 🧪 Testing
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,7 +48,6 @@ pub struct Config {
 impl Config {
     /// Parse config arguments
     pub fn args() -> Self {
-        // TODO: load config file before parse (maybe add new level of subcommands)
         let config = Config::parse();
         std::env::set_var("RUST_LOG", config.radio_infrastructure().log_level.clone());
         // Enables tracing under RUST_LOG variable
@@ -341,6 +340,10 @@ pub enum Commands {
     long_about = "A subgraph developer can send a gossip to inform indexers the new version of a subgraph before publishing
     ")]
     UpgradePresync(UpgradePresyncArg),
+    #[clap(aliases = ["status"], about = "Query indexing status of a subgraph deployment at allocated indexers at the current deployment of subgraph id",
+    long_about = "A subgraph developer quickly query the indexing status of a deployment (new_hash) at public status APIs of indexers actively allocated to the subgraph_id 
+    ")]
+    IndexingStatus(IndexingStatusArg),
 }
 
 #[derive(Clone, Debug, Args, Serialize, Deserialize, Default)]
@@ -358,6 +361,27 @@ pub struct UpgradePresyncArg {
         value_name = "NEW_HASH",
         env = "NEW_HASH",
         help = "Subgraph hash for the upgrade version of the subgraph"
+    )]
+    pub new_hash: String,
+}
+
+//TODO: Add network to support multi-network queries, currently just take the
+//the first chain at indexing status returned by allocated indexers
+#[derive(Clone, Debug, Args, Serialize, Deserialize, Default)]
+#[group(required = true, multiple = true)]
+pub struct IndexingStatusArg {
+    #[clap(
+        long,
+        value_name = "SUBGRAPH_ID",
+        env = "SUBGRAPH_ID",
+        help = "Subgraph id shared by the old and new deployment"
+    )]
+    pub subgraph_id: String,
+    #[clap(
+        long,
+        value_name = "NEW_HASH",
+        env = "NEW_HASH",
+        help = "Subgraph deployment hash for the upgrade version of the subgraph"
     )]
     pub new_hash: String,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,4 @@
-use once_cell::sync::OnceCell;
-use std::sync::Arc;
-
-use graphcast_sdk::graphcast_agent::GraphcastAgent;
-
 pub mod config;
 pub mod messages;
 pub mod operator;
-
-/// A global static (singleton) instance of GraphcastAgent. It is useful to ensure that we have only one GraphcastAgent
-/// per Radio instance, so that we can keep track of state and more easily test our Radio application.
-pub static GRAPHCAST_AGENT: OnceCell<Arc<GraphcastAgent>> = OnceCell::new();
+pub mod query;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::sync::mpsc;
 use dotenv::dotenv;
 use graphcast_cli::{
     config::{Commands, Config},
-    operator::RadioOperator,
+    operator::{operation::indexing_status, RadioOperator},
 };
 use graphcast_sdk::{graphcast_agent::GraphcastAgent, WakuMessage};
 
@@ -13,20 +13,23 @@ async fn main() {
     // Parse basic configurations
     let radio_config = Config::args();
 
-    // The channel is not used in CLI
-    let (sender, _) = mpsc::channel::<WakuMessage>();
-    let agent = GraphcastAgent::new(
-        radio_config.to_graphcast_agent_config().await.unwrap(),
-        sender,
-    )
-    .await
-    .expect("Initialize Graphcast agent");
-
-    let radio_operator = RadioOperator::new(&radio_config, agent).await;
-
-    match radio_config.subcommand() {
+    match &radio_config.subcommand() {
         Commands::UpgradePresync(args) => {
+            // The channel is not used in CLI
+            let (sender, _) = mpsc::channel::<WakuMessage>();
+            let agent = GraphcastAgent::new(
+                radio_config.to_graphcast_agent_config().await.unwrap(),
+                sender,
+            )
+            .await
+            .expect("Initialize Graphcast agent");
+
+            let radio_operator = RadioOperator::new(&radio_config, agent).await;
             radio_operator.upgrade_presync(args).await;
+        }
+        Commands::IndexingStatus(args) => {
+            // No graphcast agent or radio operator needed
+            indexing_status(&radio_config, args).await;
         }
     };
 }

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -1,11 +1,9 @@
-use graphcast_sdk::graphql::client_graph_account::subgraph_hash_by_id;
 use std::sync::Arc;
-use tracing::{debug, warn};
+use tracing::debug;
 
 use graphcast_sdk::graphcast_agent::GraphcastAgent;
 
-use crate::config::{Config, UpgradePresyncArg};
-use crate::GRAPHCAST_AGENT;
+use crate::config::Config;
 pub mod operation;
 
 /// Radio operator contains all states needed for radio operations
@@ -22,8 +20,6 @@ impl RadioOperator {
         debug!("Initializing Graphcast Agent");
         let graphcast_agent = Arc::new(agent);
 
-        _ = GRAPHCAST_AGENT.set(graphcast_agent.clone());
-
         RadioOperator {
             config: config.clone(),
             graphcast_agent,
@@ -32,33 +28,5 @@ impl RadioOperator {
 
     pub fn graphcast_agent(&self) -> &GraphcastAgent {
         &self.graphcast_agent
-    }
-
-    /// radio continuously attempt to send message until success
-    pub async fn upgrade_presync(&self, args: &UpgradePresyncArg) {
-        let mut current_attempt: u64 = 0;
-
-        // Set subscription topic
-        let identifier = subgraph_hash_by_id(
-            self.config.graph_stack().network_subgraph(),
-            &self.config.graph_stack().graph_account,
-            &args.subgraph_id,
-        )
-        .await
-        .expect("Failed to match the upgrade intent with an existing subgraph deployment");
-        self.graphcast_agent
-            .update_content_topics(vec![identifier])
-            .await;
-
-        let mut res = self.gossip_one_shot(args).await;
-        // Try again if the gossip failed to send while the attempt number is within max_retry
-        while res.is_err() && current_attempt < self.config.max_retry {
-            warn!(
-                err = tracing::field::debug(&res),
-                current_attempt, "Failed to gossip, retry"
-            );
-            current_attempt += 1;
-            res = self.gossip_one_shot(args).await;
-        }
     }
 }

--- a/src/operator/operation.rs
+++ b/src/operator/operation.rs
@@ -76,8 +76,6 @@ impl RadioOperator {
 /// Query the new deployment indexing status at public status endpoints registered
 /// by the indexers who are actively allocating the current deployment
 pub async fn indexing_status(config: &Config, args: &IndexingStatusArg) {
-    let _current_attempt: u64 = 0;
-
     // Get list of public status APIs
     let public_status_apis = query_indexer_public_api(&config.graph_stack().network_subgraph, &args.subgraph_id).await
         .expect("Could not query public status APIs from indexers actively allocated on the network subgraph");

--- a/src/operator/operation.rs
+++ b/src/operator/operation.rs
@@ -1,12 +1,14 @@
 use chrono::Utc;
 use graphcast_sdk::graphql::client_graph_account::subgraph_hash_by_id;
-use tracing::{error, info};
+use graphcast_sdk::graphql::QueryError;
+use tracing::{debug, error, info, warn};
 
 use graphcast_sdk::graphcast_agent::GraphcastAgentError;
 
-use crate::config::UpgradePresyncArg;
+use crate::config::{Config, IndexingStatusArg, UpgradePresyncArg};
 use crate::messages::upgrade::UpgradeIntentMessage;
 use crate::operator::RadioOperator;
+use crate::query::{query_indexer_public_api, query_indexing_statuses, IndexerInfo};
 
 impl RadioOperator {
     pub async fn gossip_one_shot(
@@ -41,4 +43,98 @@ impl RadioOperator {
             }
         }
     }
+
+    /// radio attempt to send message until success or max at configured retry
+    pub async fn upgrade_presync(&self, args: &UpgradePresyncArg) {
+        let mut current_attempt: u64 = 0;
+
+        // Set subscription topic
+        let identifier = subgraph_hash_by_id(
+            self.config.graph_stack().network_subgraph(),
+            &self.config.graph_stack().graph_account,
+            &args.subgraph_id,
+        )
+        .await
+        .expect("Failed to match the upgrade intent with an existing subgraph deployment");
+        self.graphcast_agent
+            .update_content_topics(vec![identifier])
+            .await;
+
+        let mut res = self.gossip_one_shot(args).await;
+        // Try again if the gossip failed to send while the attempt number is within max_retry
+        while res.is_err() && current_attempt < self.config.max_retry {
+            warn!(
+                err = tracing::field::debug(&res),
+                current_attempt, "Failed to gossip, retry"
+            );
+            current_attempt += 1;
+            res = self.gossip_one_shot(args).await;
+        }
+    }
+}
+
+/// Query the new deployment indexing status at public status endpoints registered
+/// by the indexers who are actively allocating the current deployment
+pub async fn indexing_status(config: &Config, args: &IndexingStatusArg) {
+    let _current_attempt: u64 = 0;
+
+    // Get list of public status APIs
+    let public_status_apis = query_indexer_public_api(&config.graph_stack().network_subgraph, &args.subgraph_id).await
+        .expect("Could not query public status APIs from indexers actively allocated on the network subgraph");
+    info!(
+        num_apis = public_status_apis.len(),
+        "Number of APIs to query indexing status"
+    );
+
+    // Query all the public status APIs for new_hash indexing_status
+    let new_hash_statuses = query_indexing_statuses(public_status_apis, &args.new_hash).await;
+    debug!("new_hash_statuses {:#?}", new_hash_statuses);
+    // Summarize the results
+    summarize_indexing_statuses(new_hash_statuses);
+}
+
+/// Summarize indexing statuses: Number of indexers,
+pub fn summarize_indexing_statuses(statuses: Vec<Result<IndexerInfo, QueryError>>) {
+    let okay_results: Vec<IndexerInfo> = statuses
+        .iter()
+        .filter_map(|r| r.as_ref().ok())
+        .cloned()
+        .collect();
+    let synced_indexers = okay_results
+        .iter()
+        .filter(|&indexer| indexer.status.synced)
+        .count();
+    //TODO: to support multiple chains, check chains id specifications, right now brutally taking the first chain
+    let block_progress: String = okay_results
+        .iter()
+        .max_by_key(|indexer| indexer.latest_block_number())
+        .map(|indexer| {
+            let chain_head = indexer.chain_head_block_number();
+            let latest = indexer.latest_block_number();
+            format!("{} / {}", chain_head, latest)
+        })
+        .unwrap_or(String::from("N/A"));
+    let num_indexing_indexers = okay_results.len();
+    let avg_progress: f32 = okay_results
+        .iter()
+        .map(|indexer| {
+            let progress = indexer.latest_block_number() as f32
+                / indexer.chain_head_block_number() as f32
+                * 100.0;
+            debug!(
+                indexer = tracing::field::debug(&indexer.info),
+                progress, "Indexer statuses"
+            );
+            progress
+        })
+        .sum::<f32>()
+        / num_indexing_indexers as f32;
+    info!(
+        num_currently_allocated_indexer_apis = statuses.len(),
+        num_indexing_indexers = num_indexing_indexers,
+        num_synced_indexers = synced_indexers,
+        latest_synced_block = block_progress,
+        average_progress = format!("{}%", avg_progress),
+        "Indexing statuses summary"
+    );
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,0 +1,216 @@
+use graphcast_sdk::graphql::QueryError;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tracing::{debug, trace};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexerUrl {
+    pub id: String,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexerInfo {
+    pub info: IndexerUrl,
+    pub status: IndexingStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IndexingStatus {
+    pub health: SubgraphHealth,
+    pub synced: bool,
+    pub chains: Vec<ChainStatus>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[allow(non_camel_case_types)] // Need exact field names to match with GQL response
+pub enum SubgraphHealth {
+    healthy,
+    unhealthy,
+    failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChainStatus {
+    pub network: String,
+    pub latest_block: Block,
+    pub chain_head_block: Block,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Block {
+    pub number: String,
+    pub hash: String,
+}
+
+impl IndexerInfo {
+    pub fn latest_block_number(&self) -> i32 {
+        self.status.chains[0]
+            .latest_block
+            .number
+            .parse::<i32>()
+            .unwrap()
+    }
+
+    pub fn chain_head_block_number(&self) -> i32 {
+        self.status.chains[0]
+            .chain_head_block
+            .number
+            .parse::<i32>()
+            .unwrap()
+    }
+}
+
+/// Construct indexer url query
+pub fn active_indexer_url(subgraph_id: &str) -> serde_json::Value {
+    json!({
+        "query": r#"query subgraph($id: String!){
+            subgraph(id: $id) {
+            currentVersion{
+              subgraphDeployment{
+                indexerAllocations{
+                  indexer {
+                    id
+                    url
+                  }
+                }
+              }
+            }
+          }
+        }"#,
+        "variables": {
+            "id": subgraph_id.to_string(),
+        },
+    })
+}
+
+/// Construct indexing status query
+pub fn status_query(deployment: &str) -> serde_json::Value {
+    json!({
+        "query": r#"query indexingStatus($subgraphs: [String!]!) {
+            indexingStatuses(subgraphs: $subgraphs) {
+                subgraph
+                health
+                synced
+                chains {
+                    network
+                    ... on EthereumIndexingStatus {
+                        latestBlock { number hash }
+                        chainHeadBlock { number hash }
+                    }
+                }
+            }
+        }"#,
+        "variables": {
+            "subgraphs": [deployment.to_string()],
+        },
+    })
+}
+
+/// Query the network subgraph to get a list of indexer id to their
+/// public status endpoint registered by the indexers allocating to the
+/// current deployment of the subgraph
+pub async fn query_indexer_public_api(
+    network_subgraph_endpoint: &str,
+    subgraph_id: &str,
+) -> Result<Vec<IndexerUrl>, QueryError> {
+    // Create GraphQL query string
+    let query = active_indexer_url(subgraph_id);
+
+    // Send the GraphQL request
+    let response = reqwest::Client::new()
+        .post(network_subgraph_endpoint)
+        .header("Content-Type", "application/json")
+        .json(&query)
+        .send()
+        .await?;
+
+    // Deserialize the JSON response
+    let data: serde_json::Value = response.json().await?;
+    let indexer_urls = data["data"]["subgraph"]["currentVersion"]["subgraphDeployment"]
+        ["indexerAllocations"]
+        .as_array()
+        .unwrap_or_else(|| panic!("Could not get indexer public status APIs"))
+        .iter()
+        .filter_map(|v| serde_json::from_value::<IndexerUrl>(v["indexer"].clone()).ok())
+        .collect::<Vec<IndexerUrl>>();
+    debug!(
+        indexer_urls = tracing::field::debug(&indexer_urls),
+        "Queried Indexer URLs"
+    );
+    Ok(indexer_urls)
+}
+
+/// Query the network subgraph to get a hashmap of indexer id to their
+/// public status endpoint registered by the indexers allocating to the
+/// current deployment of the subgraph
+pub async fn query_indexing_status(
+    indexer_url: IndexerUrl,
+    deployment: String,
+) -> Result<IndexerInfo, QueryError> {
+    // Create GraphQL query string
+    let query = status_query(&deployment);
+    let status_endpoint = indexer_url.url.to_string() + "status";
+    // Send the GraphQL request
+    let response = reqwest::Client::new()
+        .post(status_endpoint)
+        .header("Content-Type", "application/json")
+        .json(&query)
+        .send()
+        .await?;
+    trace!("response: {:#?}", &response);
+
+    // Deserialize the JSON response
+    let data: serde_json::Value = response.json().await?;
+    let indexing_status =
+        serde_json::from_value::<IndexingStatus>(data["data"]["indexingStatuses"][0].clone())
+            .map_err(|e| QueryError::Other(e.into()))?;
+
+    debug!(
+        indexer = tracing::field::debug(&indexer_url),
+        indexing_status = tracing::field::debug(&indexing_status),
+        "Queried indexer indexing statuses"
+    );
+    Ok(IndexerInfo {
+        info: indexer_url,
+        status: indexing_status,
+    })
+}
+
+/// Query indexing_status of a deployment indexer_urls
+pub async fn query_indexing_statuses(
+    indexer_urls: Vec<IndexerUrl>,
+    deployment: &str,
+) -> Vec<std::result::Result<IndexerInfo, QueryError>> {
+    // Loop through indexer_url to query indexing_status
+    let indexing_statuses: Vec<_> = indexer_urls
+        .iter()
+        .map(|indexer_url| query_indexing_status(indexer_url.clone(), deployment.to_string()))
+        .collect();
+    let mut handles: Vec<tokio::task::JoinHandle<Result<IndexerInfo, QueryError>>> =
+        Vec::with_capacity(indexing_statuses.len());
+
+    for fut in indexing_statuses {
+        handles.push(tokio::spawn(fut));
+    }
+
+    let mut results = Vec::with_capacity(handles.len());
+    for handle in handles {
+        results.push(handle.await.unwrap());
+    }
+    let results_len = results.len();
+
+    let err_results: Vec<&QueryError> = results
+        .iter()
+        .filter_map(|result| result.as_ref().err())
+        .collect();
+
+    debug!(
+        results = results_len,
+        err_results = err_results.len(),
+        "Number of results"
+    );
+    trace!(err_results = tracing::field::debug(&err_results), "Errors");
+    results
+}

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,7 +1,9 @@
-use graphcast_sdk::graphql::QueryError;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::time::Duration;
 use tracing::{debug, trace};
+
+use graphcast_sdk::graphql::QueryError;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IndexerUrl {
@@ -157,6 +159,7 @@ pub async fn query_indexing_status(
         .post(status_endpoint)
         .header("Content-Type", "application/json")
         .json(&query)
+        .timeout(Duration::from_secs(10))
         .send()
         .await?;
     trace!("response: {:#?}", &response);


### PR DESCRIPTION
### Description

After sending `UpgradeIntentMessage`, a developer can periodically check the indexing status of the new subgraph deployment at the public APIs of the indexers who actively allocates on the current version of the subgraph.

Same arguments here can be used as the argument for `UpgradeIntentMessage`.

Example usage
```
cargo run indexing-status --subgraph-id "0x00000444e5a1a667663b0adfd853e8efa0470698-0" --new-hash QmfDJFYaDX7BdwT6rYa8Bx71vPjTueUVDN99pdwFgysDiZ
```
Expected output
![Screenshot 2023-08-25 at 8 05 15 PM](https://github.com/graphops/graphcast-cli/assets/60078528/e003f970-4d51-4f77-ba2f-b66d03c4003f)


### Issue link (if applicable)

Resolves #8

### Checklist
- [x] Are tests up-to-date with the new changes? 
- [x] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
